### PR TITLE
Fix memory leak when cleaning up

### DIFF
--- a/CssParser/src/cssparser/CSSParser.cpp
+++ b/CssParser/src/cssparser/CSSParser.cpp
@@ -777,8 +777,20 @@ void CSSParser::clean() {
 }
 
 void CSSParser::cleanRes() {
+	for (auto item : m_selectors)
+	{
+		delete item;
+	}
 	m_selectors.clear();
+	for (auto item : m_keywords)
+	{
+		delete item;
+	}
 	m_keywords.clear();
+	for (auto item : m_signSelecors)
+	{
+		delete item;
+	}
 	m_signSelecors.clear();
 }
 

--- a/CssParser/src/cssparser/CSSParser.cpp
+++ b/CssParser/src/cssparser/CSSParser.cpp
@@ -777,18 +777,15 @@ void CSSParser::clean() {
 }
 
 void CSSParser::cleanRes() {
-	for (auto item : m_selectors)
-	{
+	for (auto item : m_selectors) {
 		delete item;
 	}
 	m_selectors.clear();
-	for (auto item : m_keywords)
-	{
+	for (auto item : m_keywords) {
 		delete item;
 	}
 	m_keywords.clear();
-	for (auto item : m_signSelecors)
-	{
+	for (auto item : m_signSelecors) {
 		delete item;
 	}
 	m_signSelecors.clear();


### PR DESCRIPTION
The library was very useful, thank you for the gumbo-less version. I noticed some memory leaks while using it and found the cause here:
The selectors and keywords are allocated with new, but the cleanup only clears the vectors/lists.